### PR TITLE
Overload dc_readhost

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,8 @@ class exim (
   $dc_local_interfaces ='127.0.0.1  ; ::1',
   $dc_relay_nets = '',
   $dc_smarthost = '',
-  $dc_hide_mailname = 'true'
+  $dc_hide_mailname = 'true',
+  $dc_readhost = "${::fqdn}"
 ) {
 
   # Module compatibility check

--- a/templates/update-exim4.conf.conf.erb
+++ b/templates/update-exim4.conf.conf.erb
@@ -3,7 +3,7 @@
 dc_eximconfig_configtype='<%= @dc_eximconfig_configtype %>'
 dc_other_hostnames='<%= @fqdn %>'
 dc_local_interfaces='<%= @dc_local_interfaces %>'
-dc_readhost='<%= @fqdn %>'
+dc_readhost='<%= @dc_readhost %>'
 dc_relay_domains=''
 dc_minimaldns='false'
 dc_relay_nets='<%= @dc_relay_nets %>'


### PR DESCRIPTION
In some specific case, dc_readhost need to be overloaded with another hostname or fdqn.
This is very usefull to masquerade the sender domain.
